### PR TITLE
Updating rollup to 0.34.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "isparta": "^4.0.0",
     "mocha": "^2.3.4",
     "rimraf": "^2.3.1",
-    "rollup": "^0.25.0",
+    "rollup": "^0.34.3",
     "rollup-plugin-babel": "^2.3.8",
     "rollup-plugin-commonjs": "^2.1.0",
     "rollup-plugin-multi-entry": "^1.0.1",


### PR DESCRIPTION
Please update [rollup](https://npmjs.org/package/rollup) to version 0.34.3.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`6ee27c6`](https://github.com/rollup/rollup/commit/6ee27c6a7dcf5619074bc9c686386d0e948aa0d1) `-> 0.34.3`
- [`d248004`](https://github.com/rollup/rollup/commit/d248004a6a351f182aa495e914d5ab8f716a11f4) `Upgrade dependencies`
- [`0bb9a4c`](https://github.com/rollup/rollup/commit/0bb9a4c1c16be438cf6cef8a55feeffdc36348e8) `Merge pull request #800 from phter/patch-2`
- [`088d12b`](https://github.com/rollup/rollup/commit/088d12bf9f206fe00d64a3f5cd332a07fadaf9d2) `Avoid infinite recursion in Bundle.sort()`
- [`23f89ab`](https://github.com/rollup/rollup/commit/23f89abf324969d03f420654a1f12f5091586081) `-> v0.34.2`
- [`3bce9d3`](https://github.com/rollup/rollup/commit/3bce9d3658f392552d6f3b452ac640b6325398e1) `Merge pull request #811 from rollup/cache-resolve`
- [`b148d70`](https://github.com/rollup/rollup/commit/b148d70125898adcf025ffa95b7e05584da189aa) `Merge pull request #814 from rollup/pretty-error`
- [`b215060`](https://github.com/rollup/rollup/commit/b215060634089526d6202b6cefdcbe1b7e307b61) `Wrap source id with quotes in unresolved error`
- [`8bca62b`](https://github.com/rollup/rollup/commit/8bca62b559e21a58b595030798b268653a316593) `Test for not resolved module`
- [`bd1c379`](https://github.com/rollup/rollup/commit/bd1c379a1791c02ea784b3d2a19e07493ad5fbd8) `Reduce transformers error message chain`
- [`684dde0`](https://github.com/rollup/rollup/commit/684dde0a30e27247c2378d91b92f73abe3757513) `Cache resolvedIds in modules to improve incrementa&hellip;`
- [`edf132e`](https://github.com/rollup/rollup/commit/edf132eecf560ee2da194a5b18a39320c4b40db1) `Treat path as external dependency`
- [`e275a9c`](https://github.com/rollup/rollup/commit/e275a9cd607d49df1f5a1d13bda897dd5b066b63) `oops`
- [`5c0597d`](https://github.com/rollup/rollup/commit/5c0597d70a4a0800bd320d20a229050d73c6daac) `-> v0.34.1`
- [`93ec667`](https://github.com/rollup/rollup/commit/93ec6672285967d9baceca264b3007a5b271713e) `more aggressive linting`

See the full [change log](https://github.com/rollup/rollup/compare/49e9fac201793b7590f70e8ece9434fb71605ee3...6ee27c6a7dcf5619074bc9c686386d0e948aa0d1) for everything that changed in this release.
